### PR TITLE
Add inspector overlay and instrumentation

### DIFF
--- a/crates/strato-core/src/inspector.rs
+++ b/crates/strato-core/src/inspector.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime};
+
+use parking_lot::RwLock;
+
+use crate::state::StateId;
+use crate::types::Rect;
+use crate::widget::WidgetId;
+
+/// Configuration for the runtime inspector.
+#[derive(Debug, Clone)]
+pub struct InspectorConfig {
+    /// Whether the inspector is allowed to capture runtime information.
+    pub enabled: bool,
+    /// Whether layout bounds should be captured on every frame.
+    pub capture_layout: bool,
+    /// Whether state mutations should be snapshotted.
+    pub capture_state: bool,
+    /// Whether performance timelines should be tracked.
+    pub capture_performance: bool,
+}
+
+impl Default for InspectorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: cfg!(debug_assertions),
+            capture_layout: true,
+            capture_state: true,
+            capture_performance: true,
+        }
+    }
+}
+
+/// A single component record in the captured hierarchy.
+#[derive(Debug, Clone)]
+pub struct ComponentNodeSnapshot {
+    pub id: WidgetId,
+    pub name: String,
+    pub depth: usize,
+    pub props: HashMap<String, String>,
+    pub state: HashMap<String, String>,
+}
+
+/// Captured layout box for a widget.
+#[derive(Debug, Clone, Copy)]
+pub struct LayoutBoxSnapshot {
+    pub widget_id: WidgetId,
+    pub bounds: Rect,
+}
+
+/// Captured state change metadata.
+#[derive(Debug, Clone)]
+pub struct StateSnapshot {
+    pub state_id: StateId,
+    pub detail: String,
+    pub recorded_at: SystemTime,
+}
+
+/// Performance timeline entry (per frame).
+#[derive(Debug, Clone)]
+pub struct FrameTimelineSnapshot {
+    pub frame_id: u64,
+    pub cpu_time_ms: f32,
+    pub gpu_time_ms: f32,
+    pub notes: Option<String>,
+}
+
+/// Complete snapshot of inspector data for rendering in the overlay.
+#[derive(Debug, Clone)]
+pub struct InspectorSnapshot {
+    pub components: Vec<ComponentNodeSnapshot>,
+    pub layout_boxes: Vec<LayoutBoxSnapshot>,
+    pub state_snapshots: Vec<StateSnapshot>,
+    pub frame_timelines: Vec<FrameTimelineSnapshot>,
+}
+
+impl Default for InspectorSnapshot {
+    fn default() -> Self {
+        Self {
+            components: Vec::new(),
+            layout_boxes: Vec::new(),
+            state_snapshots: Vec::new(),
+            frame_timelines: Vec::new(),
+        }
+    }
+}
+
+/// Runtime inspector for StratoSDK that aggregates data from multiple layers.
+pub struct Inspector {
+    config: RwLock<InspectorConfig>,
+    enabled: AtomicBool,
+    components: RwLock<Vec<ComponentNodeSnapshot>>,
+    layout_boxes: RwLock<Vec<LayoutBoxSnapshot>>,
+    state_snapshots: RwLock<HashMap<StateId, StateSnapshot>>,
+    frame_timelines: RwLock<Vec<FrameTimelineSnapshot>>,
+}
+
+impl Inspector {
+    fn new() -> Self {
+        let config = InspectorConfig::default();
+        Self {
+            enabled: AtomicBool::new(config.enabled),
+            components: RwLock::new(Vec::new()),
+            layout_boxes: RwLock::new(Vec::new()),
+            state_snapshots: RwLock::new(HashMap::new()),
+            frame_timelines: RwLock::new(Vec::new()),
+            config: RwLock::new(config),
+        }
+    }
+
+    /// Update the inspector configuration at runtime.
+    pub fn configure(&self, config: InspectorConfig) {
+        *self.config.write() = config.clone();
+        self.enabled.store(config.enabled, Ordering::Relaxed);
+    }
+
+    /// Get the current configuration.
+    pub fn config(&self) -> InspectorConfig {
+        self.config.read().clone()
+    }
+
+    /// Check if the inspector is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Enable or disable the inspector without replacing the full configuration.
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+        self.config.write().enabled = enabled;
+    }
+
+    /// Toggle inspector visibility.
+    pub fn toggle(&self) -> bool {
+        let next = !self.is_enabled();
+        self.set_enabled(next);
+        next
+    }
+
+    /// Reset transient per-frame information so the overlay always shows the latest data.
+    pub fn begin_frame(&self) {
+        self.layout_boxes.write().clear();
+        self.components.write().clear();
+    }
+
+    /// Replace the captured widget hierarchy for the current frame.
+    pub fn record_component_tree(&self, nodes: Vec<ComponentNodeSnapshot>) {
+        if !self.is_enabled() {
+            return;
+        }
+        *self.components.write() = nodes;
+    }
+
+    /// Record a layout box for a widget.
+    pub fn record_layout_box(&self, snapshot: LayoutBoxSnapshot) {
+        if !self.is_enabled() || !self.config().capture_layout {
+            return;
+        }
+        self.layout_boxes.write().push(snapshot);
+    }
+
+    /// Record a state mutation/snapshot.
+    pub fn record_state_snapshot(&self, state_id: StateId, detail: impl Into<String>) {
+        if !self.is_enabled() || !self.config().capture_state {
+            return;
+        }
+
+        self.state_snapshots.write().insert(
+            state_id,
+            StateSnapshot {
+                state_id,
+                detail: detail.into(),
+                recorded_at: SystemTime::now(),
+            },
+        );
+    }
+
+    /// Record a per-frame performance timeline entry.
+    pub fn record_frame_timeline(
+        &self,
+        frame_id: u64,
+        cpu_time: Duration,
+        gpu_time: Duration,
+        notes: Option<String>,
+    ) {
+        if !self.is_enabled() || !self.config().capture_performance {
+            return;
+        }
+
+        self.frame_timelines.write().push(FrameTimelineSnapshot {
+            frame_id,
+            cpu_time_ms: (cpu_time.as_secs_f64() * 1000.0) as f32,
+            gpu_time_ms: (gpu_time.as_secs_f64() * 1000.0) as f32,
+            notes,
+        });
+    }
+
+    /// Get the full snapshot used by the inspector overlay widget.
+    pub fn snapshot(&self) -> InspectorSnapshot {
+        InspectorSnapshot {
+            components: self.components.read().clone(),
+            layout_boxes: self.layout_boxes.read().clone(),
+            state_snapshots: self.state_snapshots.read().values().cloned().collect(),
+            frame_timelines: self.frame_timelines.read().clone(),
+        }
+    }
+}
+
+static INSPECTOR: OnceLock<Inspector> = OnceLock::new();
+
+/// Access the global inspector instance used by all layers.
+pub fn inspector() -> &'static Inspector {
+    INSPECTOR.get_or_init(Inspector::new)
+}

--- a/crates/strato-core/src/lib.rs
+++ b/crates/strato-core/src/lib.rs
@@ -3,41 +3,43 @@
 //! This crate provides the fundamental building blocks for the StratoUI framework,
 //! including state management, event handling, and layout calculations.
 
-pub mod event;
-pub mod layout;
-pub mod state;
-pub mod reactive;
-pub mod types;
+pub mod config;
 pub mod error;
+pub mod event;
+pub mod hot_reload;
+pub mod inspector;
+pub mod layout;
+pub mod logging;
+pub mod plugin;
+pub mod reactive;
+pub mod state;
+pub mod text;
+pub mod theme;
+pub mod types;
+pub mod ui_node;
 pub mod vdom;
 pub mod widget;
 pub mod window;
-pub mod hot_reload;
-pub mod theme;
-pub mod plugin;
-pub mod text;
-pub mod logging;
-pub mod config;
-pub mod ui_node;
 
+pub use error::{Result, StratoError, StratoResult};
 pub use event::{Event, EventHandler, EventResult};
-pub use layout::{Constraints, Layout, LayoutEngine, LayoutConstraints, Size};
-pub use state::{Signal, State};
+pub use layout::{Constraints, Layout, LayoutConstraints, LayoutEngine, Size};
+pub use logging::{LogCategory, LogLevel};
 pub use reactive::{Computed, Effect, Reactive};
+pub use state::{Signal, State};
 pub use types::{Color, Point, Rect, Transform};
-pub use error::{StratoError, StratoResult, Result};
-pub use logging::{LogLevel, LogCategory};
 
 /// Re-export commonly used types
 pub mod prelude {
     pub use crate::{
+        error::{Result, StratoError},
         event::{Event, EventHandler, EventResult},
+        inspector::{inspector, InspectorConfig, InspectorSnapshot},
         layout::{Constraints, Layout, Size},
-        state::{Signal, State},
+        logging::LogLevel,
         reactive::{Computed, Effect},
+        state::{Signal, State},
         types::{Color, Point, Rect},
-        error::{StratoError, Result},
-        logging::{LogLevel},
     };
 }
 
@@ -49,12 +51,12 @@ pub fn init() -> Result<()> {
     // Initialize logging system with default config
     let config = config::LoggingConfig::default();
     if let Err(e) = logging::init(&config) {
-        return Err(StratoError::Initialization { 
+        return Err(StratoError::Initialization {
             message: format!("Failed to initialize logging: {}", e),
             context: None,
         });
     }
-    
+
     // Initialize tracing
     tracing::info!("StratoUI Core v{} initialized", VERSION);
     Ok(())

--- a/crates/strato-widgets/src/inspector.rs
+++ b/crates/strato-widgets/src/inspector.rs
@@ -1,0 +1,271 @@
+//! In-app inspector overlay for visualizing widget trees, state snapshots, and performance timelines.
+
+use std::collections::HashMap;
+
+use glam::Vec2;
+use strato_core::event::{Event, EventResult, KeyCode, KeyboardEvent, Modifiers};
+use strato_core::inspector::{self, ComponentNodeSnapshot, InspectorSnapshot, LayoutBoxSnapshot};
+use strato_core::layout::{Constraints, Layout, Size};
+use strato_core::types::{Color, Rect, Transform};
+use strato_renderer::batch::RenderBatch;
+
+use crate::container::Container;
+use crate::layout::Column;
+use crate::scroll_view::ScrollView;
+use crate::text::Text;
+use crate::widget::{generate_id, Widget, WidgetId};
+
+const DEFAULT_PANEL_WIDTH: f32 = 340.0;
+const DEFAULT_PANEL_HEIGHT: f32 = 320.0;
+
+/// Overlay widget that renders the inspector panel and captures instrumentation data.
+#[derive(Debug)]
+pub struct InspectorOverlay {
+    id: WidgetId,
+    child: Box<dyn Widget>,
+    shortcut: (KeyCode, Modifiers),
+    pub visible: bool,
+    cached_child_size: Size,
+    panel: Option<Box<dyn Widget>>,
+    panel_size: Option<Size>,
+}
+
+impl InspectorOverlay {
+    /// Create a new overlay wrapping the provided child widget.
+    pub fn new(child: impl Widget + 'static) -> Self {
+        Self {
+            id: generate_id(),
+            child: Box::new(child),
+            shortcut: (
+                KeyCode::I,
+                Modifiers {
+                    control: true,
+                    shift: true,
+                    alt: false,
+                    super_key: false,
+                },
+            ),
+            visible: false,
+            cached_child_size: Size::zero(),
+            panel: None,
+            panel_size: None,
+        }
+    }
+
+    /// Override the keyboard shortcut used to toggle visibility.
+    pub fn shortcut(mut self, key: KeyCode, modifiers: Modifiers) -> Self {
+        self.shortcut = (key, modifiers);
+        self
+    }
+
+    fn shortcut_pressed(&self, key: &KeyboardEvent) -> bool {
+        key.key_code == self.shortcut.0
+            && key.modifiers.control == self.shortcut.1.control
+            && key.modifiers.shift == self.shortcut.1.shift
+            && key.modifiers.alt == self.shortcut.1.alt
+            && key.modifiers.super_key == self.shortcut.1.super_key
+    }
+
+    fn collect_components(
+        &self,
+        widget: &(dyn Widget + '_),
+        depth: usize,
+        nodes: &mut Vec<ComponentNodeSnapshot>,
+    ) {
+        nodes.push(ComponentNodeSnapshot {
+            id: widget.id(),
+            name: format!("{:?}", widget),
+            depth,
+            props: HashMap::new(),
+            state: HashMap::new(),
+        });
+
+        for child in widget.children() {
+            self.collect_components(child, depth + 1, nodes);
+        }
+    }
+
+    fn build_panel(&self, snapshot: &InspectorSnapshot) -> Box<dyn Widget> {
+        let mut lines: Vec<Box<dyn Widget>> = Vec::new();
+        lines.push(Box::new(
+            Text::new("Inspector (Ctrl+Shift+I)")
+                .font_size(16.0)
+                .color(Color::rgb(1.0, 1.0, 1.0)),
+        ));
+
+        lines.push(Box::new(
+            Text::new("Component hierarchy")
+                .font_size(14.0)
+                .color(Color::rgb(0.8, 0.9, 1.0)),
+        ));
+        if snapshot.components.is_empty() {
+            lines.push(Box::new(
+                Text::new("(no widgets rendered yet)").font_size(12.0),
+            ));
+        } else {
+            for node in &snapshot.components {
+                let indent = "  ".repeat(node.depth);
+                let line = format!("{}• {} #{}", indent, node.name, node.id);
+                lines.push(Box::new(
+                    Text::new(line)
+                        .font_size(12.0)
+                        .color(Color::rgb(0.9, 0.9, 0.9)),
+                ));
+            }
+        }
+
+        lines.push(Box::new(
+            Text::new("State snapshots")
+                .font_size(14.0)
+                .color(Color::rgb(0.8, 0.9, 1.0)),
+        ));
+        if snapshot.state_snapshots.is_empty() {
+            lines.push(Box::new(
+                Text::new("(no state mutations captured)").font_size(12.0),
+            ));
+        } else {
+            for snapshot in snapshot.state_snapshots.iter().take(8) {
+                let line = format!("• {} => {}", snapshot.state_id.data(), snapshot.detail);
+                lines.push(Box::new(Text::new(line).font_size(12.0)));
+            }
+        }
+
+        lines.push(Box::new(
+            Text::new("Layout boxes")
+                .font_size(14.0)
+                .color(Color::rgb(0.8, 0.9, 1.0)),
+        ));
+        lines.push(Box::new(
+            Text::new(format!(
+                "{} boxes captured this frame",
+                snapshot.layout_boxes.len()
+            ))
+            .font_size(12.0),
+        ));
+
+        lines.push(Box::new(
+            Text::new("Performance timeline")
+                .font_size(14.0)
+                .color(Color::rgb(0.8, 0.9, 1.0)),
+        ));
+        if snapshot.frame_timelines.is_empty() {
+            lines.push(Box::new(
+                Text::new("(no frames recorded yet)").font_size(12.0),
+            ));
+        } else {
+            for frame in snapshot.frame_timelines.iter().rev().take(5) {
+                let note = frame.notes.clone().unwrap_or_else(|| "".to_string());
+                let line = format!(
+                    "• Frame {}: {:.2}ms cpu / {:.2}ms gpu {}",
+                    frame.frame_id, frame.cpu_time_ms, frame.gpu_time_ms, note
+                );
+                lines.push(Box::new(Text::new(line).font_size(12.0)));
+            }
+        }
+
+        let column = Column::new().spacing(4.0).children(lines);
+        let scrollable = ScrollView::new(column);
+
+        Box::new(
+            Container::new()
+                .padding(12.0)
+                .background(Color::rgba(0.08, 0.1, 0.14, 0.92))
+                .border(1.0, Color::rgba(0.4, 0.6, 1.0, 0.4))
+                .child(scrollable),
+        )
+    }
+}
+
+impl Widget for InspectorOverlay {
+    fn id(&self) -> WidgetId {
+        self.id
+    }
+
+    fn layout(&mut self, constraints: Constraints) -> Size {
+        let inspector = inspector::inspector();
+        if inspector.is_enabled() && self.visible {
+            inspector.begin_frame();
+            let mut nodes = Vec::new();
+            self.collect_components(self.child.as_ref(), 0, &mut nodes);
+            inspector.record_component_tree(nodes);
+        }
+
+        self.cached_child_size = self.child.layout(constraints);
+
+        if inspector::inspector().is_enabled() && self.visible {
+            let snapshot = inspector::inspector().snapshot();
+            let mut panel = self.build_panel(&snapshot);
+            let panel_constraints = Constraints {
+                min_width: DEFAULT_PANEL_WIDTH,
+                max_width: DEFAULT_PANEL_WIDTH,
+                min_height: 0.0,
+                max_height: constraints.max_height.min(DEFAULT_PANEL_HEIGHT),
+            };
+            self.panel_size = Some(panel.layout(panel_constraints));
+            self.panel = Some(panel);
+        } else {
+            self.panel = None;
+            self.panel_size = None;
+        }
+
+        self.cached_child_size
+    }
+
+    fn render(&self, batch: &mut RenderBatch, layout: Layout) {
+        let child_layout = Layout::new(layout.position, self.cached_child_size);
+        self.child.render(batch, child_layout);
+
+        if inspector::inspector().is_enabled() && self.visible {
+            inspector::inspector().record_layout_box(LayoutBoxSnapshot {
+                widget_id: self.child.id(),
+                bounds: Rect::new(
+                    layout.position.x,
+                    layout.position.y,
+                    self.cached_child_size.width,
+                    self.cached_child_size.height,
+                ),
+            });
+
+            let snapshot = inspector::inspector().snapshot();
+            for layout_box in &snapshot.layout_boxes {
+                batch.add_rect(
+                    layout_box.bounds,
+                    Color::rgba(0.1, 0.7, 1.0, 0.15),
+                    Transform::identity(),
+                );
+            }
+
+            if let (Some(panel), Some(panel_size)) = (&self.panel, self.panel_size) {
+                let panel_pos = Vec2::new(
+                    layout.position.x + layout.size.width - panel_size.width - 12.0,
+                    layout.position.y + 12.0,
+                );
+                let panel_layout = Layout::new(panel_pos, panel_size);
+                panel.render(batch, panel_layout);
+
+                inspector::inspector().record_layout_box(LayoutBoxSnapshot {
+                    widget_id: panel.id(),
+                    bounds: Rect::new(
+                        panel_pos.x,
+                        panel_pos.y,
+                        panel_size.width,
+                        panel_size.height,
+                    ),
+                });
+            }
+        }
+    }
+
+    fn handle_event(&mut self, event: &Event) -> EventResult {
+        if let Event::KeyDown(key) = event {
+            if self.shortcut_pressed(key) {
+                let now_visible = !self.visible;
+                self.visible = now_visible;
+                inspector::inspector().set_enabled(now_visible);
+                return EventResult::Handled;
+            }
+        }
+
+        self.child.handle_event(event)
+    }
+}

--- a/crates/strato-widgets/src/lib.rs
+++ b/crates/strato-widgets/src/lib.rs
@@ -1,46 +1,49 @@
 //! StratoUI Widgets - A comprehensive widget library for StratoUI
-//! 
+//!
 //! This crate provides a collection of UI widgets built on top of the StratoUI core framework.
 //! All widgets are designed to be composable, reactive, and performant.
 
-pub mod widget;
-pub mod button;
-pub mod text;
-pub mod container;
-pub mod input;
-pub mod layout;
-pub mod theme;
-pub mod wrap;
-pub mod grid;
 pub mod animation;
 pub mod builder;
+pub mod button;
 pub mod checkbox;
-pub mod slider;
+pub mod container;
 pub mod dropdown;
+pub mod grid;
 pub mod image;
-pub mod scroll_view;
+pub mod input;
+pub mod inspector;
+pub mod layout;
 pub mod registry;
+pub mod scroll_view;
+pub mod slider;
+pub mod text;
+pub mod theme;
+pub mod widget;
+pub mod wrap;
 
 pub mod prelude;
 use crate::prelude::*;
 
 // Re-export all widget types for easy access
-pub use strato_macros::view;
-pub use widget::{Widget, WidgetContext, WidgetId};
-pub use button::{Button, ButtonStyle};
-pub use text::{Text, TextStyle};
-pub use container::{Container, ContainerStyle};
-pub use input::{TextInput, InputStyle, InputType};
-pub use layout::{Row, Column, Stack, Flex};
-pub use theme::{Theme};
 pub use builder::WidgetBuilder;
-pub use checkbox::{Checkbox, RadioButton, CheckboxStyle};
-pub use slider::{Slider, ProgressBar, SliderStyle};
+pub use button::{Button, ButtonStyle};
+pub use checkbox::{Checkbox, CheckboxStyle, RadioButton};
+pub use container::{Container, ContainerStyle};
 pub use dropdown::{Dropdown, DropdownOption, DropdownStyle};
-pub use image::{Image, ImageBuilder, ImageFit, ImageSource, ImageData, ImageFormat, ImageFilter, ImageStyle};
-pub use scroll_view::ScrollView;
 pub use grid::{Grid, GridUnit};
-
+pub use image::{
+    Image, ImageBuilder, ImageData, ImageFilter, ImageFit, ImageFormat, ImageSource, ImageStyle,
+};
+pub use input::{InputStyle, InputType, TextInput};
+pub use inspector::InspectorOverlay;
+pub use layout::{Column, Flex, Row, Stack};
+pub use scroll_view::ScrollView;
+pub use slider::{ProgressBar, Slider, SliderStyle};
+pub use strato_macros::view;
+pub use text::{Text, TextStyle};
+pub use theme::Theme;
+pub use widget::{Widget, WidgetContext, WidgetId};
 
 /// Initialize the widgets module
 pub fn init() -> strato_core::Result<()> {
@@ -52,15 +55,11 @@ pub fn init() -> strato_core::Result<()> {
 pub fn example_app() -> impl Widget {
     Container::new()
         .padding(20.0)
-        .child(
-            Column::new()
-                .spacing(10.0)
-                .children(vec![
-                    Box::new(Text::new("Welcome to StratoUI")),
-                    Box::new(Button::new("Click Me")),
-                    Box::new(TextInput::new().placeholder("Enter text...")),
-                ])
-        )
+        .child(Column::new().spacing(10.0).children(vec![
+            Box::new(Text::new("Welcome to StratoUI")),
+            Box::new(Button::new("Click Me")),
+            Box::new(TextInput::new().placeholder("Enter text...")),
+        ]))
 }
 
 #[cfg(test)]

--- a/docs/INSPECTOR.md
+++ b/docs/INSPECTOR.md
@@ -1,0 +1,29 @@
+# StratoSDK Inspector Overlay
+
+The inspector provides an in-app panel that visualizes the widget hierarchy, recent state snapshots, layout boxes, and frame timelines so you can debug rendering behavior without leaving the running app.
+
+## Toggling the overlay
+- Press **Ctrl+Shift+I** (configurable when constructing `InspectorOverlay`) to toggle the panel at runtime.
+- You can also enable/disable programmatically with `strato_core::inspector::inspector().set_enabled(bool)`.
+
+## Development vs. production defaults
+- In **debug/development builds** (`cfg!(debug_assertions)`), the inspector is enabled by default. Instrumentation hooks capture layout and state changes automatically.
+- In **release/production builds**, disable the inspector to remove overhead:
+  - Call `inspector().configure(InspectorConfig { enabled: false, ..Default::default() })` during startup, or
+  - Wrap your root widget in `InspectorOverlay` only for debug builds (`#[cfg(debug_assertions)]`).
+
+## Adding the overlay to your UI
+```rust
+use strato_widgets::InspectorOverlay;
+
+let app = build_app_ui();
+let instrumented = InspectorOverlay::new(app);
+```
+
+The overlay renders a compact panel with:
+- **Component hierarchy**: per-widget IDs and depth.
+- **State snapshots**: the latest serialized signal updates.
+- **Layout boxes**: highlighted rectangles overlaying the current frame.
+- **Performance timeline**: per-frame CPU/GPU timings from the renderer profiler.
+
+No additional plumbing is required—the overlay pulls data from the shared inspector instrumentation in `strato-core` and `strato-renderer`.


### PR DESCRIPTION
## Summary
- add a shared inspector service for capturing component trees, layout boxes, state snapshots, and frame timelines
- instrument signal updates and the renderer profiler to feed inspector data
- introduce an in-app InspectorOverlay widget and documentation for enabling or disabling it per build

## Testing
- cargo fmt --all -- crates/strato-core/src/inspector.rs crates/strato-core/src/lib.rs crates/strato-core/src/state.rs crates/strato-renderer/src/profiler.rs crates/strato-widgets/src/inspector.rs crates/strato-widgets/src/lib.rs *(fails: existing trailing whitespace in example sources)*

