### PR TITLE
Add inspector overlay to examples

### DIFF
--- a/examples/animated_showcase/src/main.rs
+++ b/examples/animated_showcase/src/main.rs
@@ -1,14 +1,21 @@
+use std::time::Duration;
+use strato_core::inspector::{inspector, InspectorConfig};
+use strato_core::state::Signal;
+use strato_core::types::Color;
 use strato_platform::{ApplicationBuilder, WindowBuilder};
+use strato_widgets::animation::{Curve, KeyframeAnimation, Parallel, Timeline, Tween};
 use strato_widgets::prelude::*;
 use strato_widgets::scroll_view::ScrollView;
-use strato_widgets::animation::{Timeline, Parallel, KeyframeAnimation, Tween, Curve};
-use strato_core::types::Color;
-use strato_core::state::Signal;
-use std::time::Duration;
+use strato_widgets::InspectorOverlay;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
+
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
 
     // Create state for animation targets
     let box_color = Signal::new(Color::RED);
@@ -17,53 +24,56 @@ async fn main() -> anyhow::Result<()> {
     // Create a ScrollView content
     let mut list = Column::new().spacing(10.0);
     for i in 0..20 {
-        list = list.child(
-            Box::new(Container::new()
+        list = list.child(Box::new(
+            Container::new()
                 .padding(20.0)
-                .background(if i % 2 == 0 { Color::rgba(0.2, 0.2, 0.2, 1.0) } else { Color::rgba(0.3, 0.3, 0.3, 1.0) })
-                .child(Text::new(format!("Scroll Item {}", i)).color(Color::WHITE)))
-        );
+                .background(if i % 2 == 0 {
+                    Color::rgba(0.2, 0.2, 0.2, 1.0)
+                } else {
+                    Color::rgba(0.3, 0.3, 0.3, 1.0)
+                })
+                .child(Text::new(format!("Scroll Item {}", i)).color(Color::WHITE)),
+        ));
     }
 
     let scroll_view = ScrollView::new(list);
 
     // Setup animation
     let mut timeline = Timeline::new();
-    
+
     // Animation 1: Change color Red -> Blue
     let color_anim = KeyframeAnimation::new(
         Duration::from_secs(2),
         Tween::new(Color::RED, Color::BLUE),
-        box_color.clone()
-    ).with_curve(Curve::EaseInOut);
+        box_color.clone(),
+    )
+    .with_curve(Curve::EaseInOut);
 
     // Animation 2: Change width 100 -> 300
     let width_anim = KeyframeAnimation::new(
         Duration::from_secs(2),
         Tween::new(100.0, 300.0),
-        box_width.clone()
-    ).with_curve(Curve::EaseOut);
+        box_width.clone(),
+    )
+    .with_curve(Curve::EaseOut);
 
     // Run parallel
     let parallel = Parallel::new(vec![Box::new(color_anim), Box::new(width_anim)]);
-    
+
     timeline.add(parallel);
     timeline.play();
 
     ApplicationBuilder::new()
         .title("Animated Showcase")
         .window(WindowBuilder::new().with_size(1024.0, 768.0))
-        .run(Container::new()
-            .child(
-                Row::new()
-                    .child(Box::new(scroll_view))
-                    .child(
-                        Box::new(Container::new()
-                            .width(300.0)
-                            .background(Color::BLACK)
-                            .child(Text::new("Animation Placeholder")))
-                            
-                        )
-            )
-        );
+        .run(InspectorOverlay::new(
+            Container::new().child(
+                Row::new().child(Box::new(scroll_view)).child(Box::new(
+                    Container::new()
+                        .width(300.0)
+                        .background(Color::BLACK)
+                        .child(Text::new("Animation Placeholder")),
+                )),
+            ),
+        ));
 }

--- a/examples/calculator/src/main.rs
+++ b/examples/calculator/src/main.rs
@@ -1,21 +1,17 @@
-use strato_sdk::prelude::*;
-use strato_widgets::{
-
-    text::TextAlign,
-    Flex,
-};
-use strato_platform::{
-    ApplicationBuilder,
-    WindowBuilder,
-    init::{InitBuilder, InitConfig},
-};
-use strato_core::event::{Event, EventResult, MouseEvent};
-use strato_core::types::{Point, Rect, Transform, Color};
-use strato_core::state::Signal;
-use strato_widgets::animation::{AnimationController, Curve};
+use std::any::Any;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::any::Any;
+use strato_core::event::{Event, EventResult, MouseEvent};
+use strato_core::inspector::{inspector, InspectorConfig};
+use strato_core::state::Signal;
+use strato_core::types::{Color, Point, Rect, Transform};
+use strato_platform::{
+    init::{InitBuilder, InitConfig},
+    ApplicationBuilder, WindowBuilder,
+};
+use strato_sdk::prelude::*;
+use strato_widgets::animation::{AnimationController, Curve};
+use strato_widgets::{text::TextAlign, Flex, InspectorOverlay};
 
 #[derive(Clone, Debug)]
 enum Operation {
@@ -28,7 +24,7 @@ enum Operation {
 #[derive(Clone, Debug)]
 struct CalculatorState {
     display: Signal<String>,
-    expression: Signal<String>, // Shows full operation like "12 + 5"
+    expression: Signal<String>,   // Shows full operation like "12 + 5"
     history: Signal<Vec<String>>, // Stores past calculations
     current_value: f64,
     previous_value: f64,
@@ -63,12 +59,12 @@ impl CalculatorState {
                 self.display.update(|s| s.push_str(&digit.to_string()));
             }
         }
-        
+
         // Update expression
         // If we just finished an operation (equals), start over unless an operator was pressed
         // For simplicity in this step, we just append to expression if it's part of the current number
         // A more robust approach updates expression based entirely on state
-        
+
         self.current_value = self.display.get().parse().unwrap_or(0.0);
     }
 
@@ -111,42 +107,48 @@ impl CalculatorState {
             } else if result.fract() == 0.0 && result.abs() < 1e10 {
                 format!("{}", result as i64)
             } else {
-                format!("{:.8}", result).trim_end_matches('0').trim_end_matches('.').to_string()
+                format!("{:.8}", result)
+                    .trim_end_matches('0')
+                    .trim_end_matches('.')
+                    .to_string()
             };
             self.display.set(display_val.clone());
-            
+
             // If equals was pressed (next_operation is None)
             if next_operation.is_none() {
-                 let op_str = match op {
+                let op_str = match op {
                     Operation::Add => "+",
                     Operation::Subtract => "-",
                     Operation::Multiply => "×",
                     Operation::Divide => "÷",
-                 };
-                 let history_entry = format!("{} {} {} = {}", 
-                    self.format_number(self.previous_value), 
-                    op_str, 
+                };
+                let history_entry = format!(
+                    "{} {} {} = {}",
+                    self.format_number(self.previous_value),
+                    op_str,
                     self.format_number(self.current_value), // This is actually the 2nd operand before result, but we overwrote it. Needs fix separately or simplified logic.
                     display_val
-                 );
-                 // Correction: We overwrote current_value with result. We should have stored 2nd operand.
-                 // For now let's just push " = result" logic or simplify.
-                 // Let's implement a better input tracking.
-                 
-                 // IMPROVED LOGIC:
-                 // We need to track the operands better for the history string.
-                 // But strictly following the plan: track history.
-                 
-                 // Let's construct history string properly.
-                 // We'll rely on expression updates in a dedicated manner in a future step if needed,
-                 // but here let's set expression to empty or result.
-                 self.expression.set("".to_string());
-                 
-                 // Add to history
-                 self.history.update(|h| {
-                     h.push(history_entry);
-                     if h.len() > 5 { h.remove(0); } // Keep last 5
-                 });
+                );
+                // Correction: We overwrote current_value with result. We should have stored 2nd operand.
+                // For now let's just push " = result" logic or simplify.
+                // Let's implement a better input tracking.
+
+                // IMPROVED LOGIC:
+                // We need to track the operands better for the history string.
+                // But strictly following the plan: track history.
+
+                // Let's construct history string properly.
+                // We'll rely on expression updates in a dedicated manner in a future step if needed,
+                // but here let's set expression to empty or result.
+                self.expression.set("".to_string());
+
+                // Add to history
+                self.history.update(|h| {
+                    h.push(history_entry);
+                    if h.len() > 5 {
+                        h.remove(0);
+                    } // Keep last 5
+                });
             }
         }
 
@@ -159,14 +161,15 @@ impl CalculatorState {
             };
             // Update expression display: "Result + "
             let current_display = self.display.get();
-            self.expression.set(format!("{} {}", current_display, op_symbol));
+            self.expression
+                .set(format!("{} {}", current_display, op_symbol));
         }
 
         self.waiting_for_operand = true;
         self.operation = next_operation;
         self.previous_value = self.current_value;
     }
-    
+
     fn format_number(&self, num: f64) -> String {
         if num.fract() == 0.0 {
             format!("{}", num as i64)
@@ -185,22 +188,29 @@ fn main() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    InitBuilder::new()
-        .with_config(config)
-        .init_all()?;
+    InitBuilder::new().with_config(config).init_all()?;
+
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
 
     println!("Calculator - StratoUI initialized with font optimizations!");
-    
+
     // Build and run the application
     ApplicationBuilder::new()
         .title("StratoUI Calculator")
-        .window(WindowBuilder::new().with_size(320.0, 480.0).resizable(false))
-        .run(build_calculator_ui())
+        .window(
+            WindowBuilder::new()
+                .with_size(320.0, 480.0)
+                .resizable(false),
+        )
+        .run(InspectorOverlay::new(build_calculator_ui()))
 }
 
 fn build_calculator_ui() -> impl Widget {
     let state = Arc::new(Mutex::new(CalculatorState::default()));
-    
+
     Container::new()
         .background(Color::rgb(0.0, 0.0, 0.0)) // Pure black background
         .padding(15.0) // Increased padding
@@ -210,39 +220,38 @@ fn build_calculator_ui() -> impl Widget {
                 .children(vec![
                     // Display
                     Box::new(create_display(state.clone())),
-                    
                     // Button grid (main block)
                     Box::new(create_button_grid(state.clone())),
-                    
                     // Button grid (bottom row with span)
                     Box::new(create_bottom_row(state.clone())),
-                ])
+                ]),
         )
 }
 
 fn create_display(state: Arc<Mutex<CalculatorState>>) -> impl Widget {
     let (display_signal, expression_signal, history_signal) = {
         let state = state.lock().unwrap();
-        (state.display.clone(), state.expression.clone(), state.history.clone())
+        (
+            state.display.clone(),
+            state.expression.clone(),
+            state.history.clone(),
+        )
     };
-    
+
     // We Wrap the Container in a Flex to ensure it takes full width of the parent Column/Container
     // effectively pushing the alignment to the far right.
     Flex::new(Box::new(
         Container::new()
             .background(Color::BLACK) // Match main background
-            // .padding(15.0) // padding handled by parent or here? 
+            // .padding(15.0) // padding handled by parent or here?
             // Parent has 15.0 padding. This container is inside that.
             // If we want text to align to the very right edge of this container,
             // we need this container to be as wide as possible.
             // The Flex below with .flex(1.0) on the *Container* itself (if Container implemented FlexItem traits directly)
             // or we use Flex widget.
             .height(150.0)
-            .child(
-                Column::new()
-                    .spacing(4.0)
-                    .children(vec![
-                        // History 
+            .child(Column::new().spacing(4.0).children(vec![
+                        // History
                         Box::new(
                              Text::new("")
                                 .bind(history_signal.map(|h| h.join("\n")))
@@ -251,9 +260,9 @@ fn create_display(state: Arc<Mutex<CalculatorState>>) -> impl Widget {
                                 .align(TextAlign::Right)
                         ),
                         Box::new(Flex::new(Box::new(
-                             Container::new().height(10.0) 
+                             Container::new().height(10.0)
                         )).flex(1.0)),
-                        // Current Expression 
+                        // Current Expression
                         Box::new(
                             Text::new("")
                                 .bind(expression_signal)
@@ -269,30 +278,41 @@ fn create_display(state: Arc<Mutex<CalculatorState>>) -> impl Widget {
                                 .color(Color::rgb(1.0, 1.0, 1.0))
                                 .align(TextAlign::Right)
                         ),
-                    ])
-            )
-    )).flex(1.0)
+                    ])),
+    ))
+    .flex(1.0)
 }
 
 fn create_button_grid(state: Arc<Mutex<CalculatorState>>) -> impl Widget {
     let buttons = vec![
         // Row 1
-        ("C", ButtonType::Clear), ("±", ButtonType::PlusMinus), ("%", ButtonType::Percent), ("÷", ButtonType::Operation(Operation::Divide)),
+        ("C", ButtonType::Clear),
+        ("±", ButtonType::PlusMinus),
+        ("%", ButtonType::Percent),
+        ("÷", ButtonType::Operation(Operation::Divide)),
         // Row 2
-        ("7", ButtonType::Digit(7)), ("8", ButtonType::Digit(8)), ("9", ButtonType::Digit(9)), ("×", ButtonType::Operation(Operation::Multiply)),
+        ("7", ButtonType::Digit(7)),
+        ("8", ButtonType::Digit(8)),
+        ("9", ButtonType::Digit(9)),
+        ("×", ButtonType::Operation(Operation::Multiply)),
         // Row 3
-        ("4", ButtonType::Digit(4)), ("5", ButtonType::Digit(5)), ("6", ButtonType::Digit(6)), ("-", ButtonType::Operation(Operation::Subtract)),
+        ("4", ButtonType::Digit(4)),
+        ("5", ButtonType::Digit(5)),
+        ("6", ButtonType::Digit(6)),
+        ("-", ButtonType::Operation(Operation::Subtract)),
         // Row 4
-        ("1", ButtonType::Digit(1)), ("2", ButtonType::Digit(2)), ("3", ButtonType::Digit(3)), ("+", ButtonType::Operation(Operation::Add)),
+        ("1", ButtonType::Digit(1)),
+        ("2", ButtonType::Digit(2)),
+        ("3", ButtonType::Digit(3)),
+        ("+", ButtonType::Operation(Operation::Add)),
     ];
 
-    let grid_items: Vec<Box<dyn Widget>> = buttons.into_iter().map(|(text, btn_type)| {
-        Box::new(AnimatedButton::new(
-            text, 
-            btn_type, 
-            state.clone()
-        )) as Box<dyn Widget>
-    }).collect();
+    let grid_items: Vec<Box<dyn Widget>> = buttons
+        .into_iter()
+        .map(|(text, btn_type)| {
+            Box::new(AnimatedButton::new(text, btn_type, state.clone())) as Box<dyn Widget>
+        })
+        .collect();
 
     Grid::new()
         .columns(vec![
@@ -306,26 +326,36 @@ fn create_button_grid(state: Arc<Mutex<CalculatorState>>) -> impl Widget {
         .children(grid_items)
 }
 
-
 fn create_bottom_row(state: Arc<Mutex<CalculatorState>>) -> impl Widget {
-    Row::new()
-        .spacing(8.0)
-        .children(vec![
-            // Zero button - Spans 2 columns worth (50%)
-            Box::new(Flex::new(
-                Box::new(AnimatedButton::new("0", ButtonType::Digit(0), state.clone()))
-            ).flex(2.0)),
-            
-            // Decimal
-            Box::new(Flex::new(
-                Box::new(AnimatedButton::new(".", ButtonType::Decimal, state.clone()))
-            ).flex(1.0)),
-            
-            // Equals
-            Box::new(Flex::new(
-                Box::new(AnimatedButton::new("=", ButtonType::Equals, state.clone()))
-            ).flex(1.0)),
-        ])
+    Row::new().spacing(8.0).children(vec![
+        // Zero button - Spans 2 columns worth (50%)
+        Box::new(
+            Flex::new(Box::new(AnimatedButton::new(
+                "0",
+                ButtonType::Digit(0),
+                state.clone(),
+            )))
+            .flex(2.0),
+        ),
+        // Decimal
+        Box::new(
+            Flex::new(Box::new(AnimatedButton::new(
+                ".",
+                ButtonType::Decimal,
+                state.clone(),
+            )))
+            .flex(1.0),
+        ),
+        // Equals
+        Box::new(
+            Flex::new(Box::new(AnimatedButton::new(
+                "=",
+                ButtonType::Equals,
+                state.clone(),
+            )))
+            .flex(1.0),
+        ),
+    ])
 }
 
 #[derive(Clone, Debug)]
@@ -353,9 +383,9 @@ struct AnimatedButton {
 
 impl AnimatedButton {
     fn new(text: &str, button_type: ButtonType, state: Arc<Mutex<CalculatorState>>) -> Self {
-        let controller = AnimationController::new(Duration::from_millis(100))
-            .with_curve(Curve::EaseOut);
-        
+        let controller =
+            AnimationController::new(Duration::from_millis(100)).with_curve(Curve::EaseOut);
+
         Self {
             id: strato_widgets::widget::generate_id(),
             text: text.to_string(),
@@ -373,40 +403,56 @@ impl Widget for AnimatedButton {
         self.id
     }
 
-    fn layout(&mut self, constraints: strato_core::layout::Constraints) -> strato_core::layout::Size {
+    fn layout(
+        &mut self,
+        constraints: strato_core::layout::Constraints,
+    ) -> strato_core::layout::Size {
         // Fill available space
         strato_core::layout::Size::new(
-            constraints.max_width, 
+            constraints.max_width,
             // 70.0 is roughly the height we want, but let's be flexible
-            constraints.max_height.min(70.0).max(50.0) 
+            constraints.max_height.min(70.0).max(50.0),
         )
     }
 
-    fn render(&self, batch: &mut strato_renderer::batch::RenderBatch, layout: strato_core::layout::Layout) {
+    fn render(
+        &self,
+        batch: &mut strato_renderer::batch::RenderBatch,
+        layout: strato_core::layout::Layout,
+    ) {
         // Update bounds for hit testing in event handling
         if let Ok(mut bounds) = self.bounds.lock() {
-            *bounds = Rect::new(layout.position.x, layout.position.y, layout.size.width, layout.size.height);
+            *bounds = Rect::new(
+                layout.position.x,
+                layout.position.y,
+                layout.size.width,
+                layout.size.height,
+            );
         }
 
         let bg_color = match self.button_type {
             ButtonType::Operation(_) | ButtonType::Equals => Color::rgb(1.0, 0.62, 0.04), // Orange (#FF9F0A)
-            ButtonType::Clear | ButtonType::PlusMinus | ButtonType::Percent => Color::rgb(0.65, 0.65, 0.65), // Light gray (#A5A5A5)
+            ButtonType::Clear | ButtonType::PlusMinus | ButtonType::Percent => {
+                Color::rgb(0.65, 0.65, 0.65)
+            } // Light gray (#A5A5A5)
             _ => Color::rgb(0.2, 0.2, 0.2), // Dark gray (#333333)
         };
-        
+
         let text_color = match self.button_type {
-            ButtonType::Clear | ButtonType::PlusMinus | ButtonType::Percent => Color::rgb(0.0, 0.0, 0.0), // Black text
+            ButtonType::Clear | ButtonType::PlusMinus | ButtonType::Percent => {
+                Color::rgb(0.0, 0.0, 0.0)
+            } // Black text
             _ => Color::rgb(1.0, 1.0, 1.0), // White text
         };
 
         // Animation logic
         let scale = if self.is_pressed {
-            0.95 
+            0.95
         } else {
             // Check animation progress if releasing
             let t = self.anim_controller.value();
             if t < 1.0 {
-                 0.95 + (0.05 * t) // rebound
+                0.95 + (0.05 * t) // rebound
             } else {
                 1.0
             }
@@ -417,30 +463,37 @@ impl Widget for AnimatedButton {
 
         // Apply scale from center
         let center = layout.size.to_vec2() / 2.0;
-        let transform = Transform::translate(layout.position.x + center.x, layout.position.y + center.y)
-            .combine(&Transform::scale(scale, scale))
-            .combine(&Transform::translate(-center.x, -center.y));
+        let transform =
+            Transform::translate(layout.position.x + center.x, layout.position.y + center.y)
+                .combine(&Transform::scale(scale, scale))
+                .combine(&Transform::translate(-center.x, -center.y));
 
         if (layout.size.width - layout.size.height).abs() < 1.0 {
             // Perfect circle (Square aspect ratio)
-            let center_pt = (layout.position.x + layout.size.width / 2.0, layout.position.y + layout.size.height / 2.0);
+            let center_pt = (
+                layout.position.x + layout.size.width / 2.0,
+                layout.position.y + layout.size.height / 2.0,
+            );
             batch.add_circle(center_pt, radius, bg_color, 32, transform);
         } else {
             // Pill shape (Width > Height, e.g., '0' button)
             // Left circle
             let left_center = (layout.position.x + radius, layout.position.y + radius);
             batch.add_circle(left_center, radius, bg_color, 32, transform);
-            
+
             // Right circle
-            let right_center = (layout.position.x + layout.size.width - radius, layout.position.y + radius);
+            let right_center = (
+                layout.position.x + layout.size.width - radius,
+                layout.position.y + radius,
+            );
             batch.add_circle(right_center, radius, bg_color, 32, transform);
-            
+
             // Middle rect
             let rect = Rect::new(
-                layout.position.x + radius, 
-                layout.position.y, 
-                layout.size.width - 2.0 * radius, 
-                layout.size.height
+                layout.position.x + radius,
+                layout.position.y,
+                layout.size.width - 2.0 * radius,
+                layout.size.height,
             );
             batch.add_rect(rect, bg_color, transform);
         }
@@ -449,12 +502,12 @@ impl Widget for AnimatedButton {
         let font_size = 32.0;
         let text_x = layout.position.x + layout.size.width / 2.0;
         let text_y = layout.position.y + layout.size.height / 2.0 - font_size / 2.0;
-        
+
         batch.add_text_aligned(
-             self.text.clone(),
-             (text_x, text_y),
-             text_color,
-             font_size,
+            self.text.clone(),
+            (text_x, text_y),
+            text_color,
+            font_size,
             0.0,
             strato_core::text::TextAlign::Center,
         );
@@ -465,7 +518,7 @@ impl Widget for AnimatedButton {
             Event::MouseDown(MouseEvent { position, .. }) => {
                 let bounds = *self.bounds.lock().unwrap();
                 let point = Point::new(position.x, position.y);
-                
+
                 if bounds.contains(point) {
                     self.is_pressed = true;
                     return EventResult::Handled;
@@ -476,11 +529,11 @@ impl Widget for AnimatedButton {
                     self.is_pressed = false;
                     self.anim_controller.reset();
                     self.anim_controller.start();
-                    
+
                     // Check if still within bounds to trigger action (standard button behavior)
                     let bounds = *self.bounds.lock().unwrap();
                     let point = Point::new(position.x, position.y);
-                    
+
                     if bounds.contains(point) {
                         // Perform action
                         handle_button_click(&self.button_type, self.state.clone());
@@ -488,7 +541,7 @@ impl Widget for AnimatedButton {
                     return EventResult::Handled;
                 }
             }
-             _ => {}
+            _ => {}
         }
         EventResult::Ignored
     }
@@ -516,7 +569,7 @@ impl Widget for AnimatedButton {
 
 fn handle_button_click(button_type: &ButtonType, state: Arc<Mutex<CalculatorState>>) {
     let mut state = state.lock().unwrap();
-    
+
     match button_type {
         ButtonType::Digit(digit) => {
             state.input_digit(*digit);
@@ -547,6 +600,6 @@ fn handle_button_click(button_type: &ButtonType, state: Arc<Mutex<CalculatorStat
             state.display.set(format!("{}", state.current_value));
         }
     }
-    
+
     println!("Calculator state: {:?}", *state);
 }

--- a/examples/complex_demo/src/main.rs
+++ b/examples/complex_demo/src/main.rs
@@ -1,18 +1,11 @@
-use strato_platform::{
-    application::Application,
-    window::WindowBuilder,
-};
-use strato_widgets::{
-    Button, ButtonStyle,
-    Column,
-    Container,
-    Row,
-    Text, TextStyle,
-    text::{FontWeight, TextAlign},
-    Widget,
-    layout::{MainAxisAlignment, CrossAxisAlignment},
-};
+use strato_core::inspector::{inspector, InspectorConfig};
 use strato_core::types::Color;
+use strato_platform::{application::Application, window::WindowBuilder};
+use strato_widgets::{
+    layout::{CrossAxisAlignment, MainAxisAlignment},
+    text::{FontWeight, TextAlign},
+    Button, ButtonStyle, Column, Container, InspectorOverlay, Row, Text, TextStyle, Widget,
+};
 
 fn main() -> anyhow::Result<()> {
     // Create application
@@ -20,36 +13,38 @@ fn main() -> anyhow::Result<()> {
         .with_title("Complex Demo")
         .with_size(1024.0, 768.0)
         .resizable(true);
-        
+
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
     let mut app = Application::new("Complex Demo", window_builder);
 
     // Create UI structure
     // Main container with background
-    let main_container = Container::new()
-        .background(Color::rgba(0.95, 0.95, 0.97, 1.0)) // Light gray background
-        .padding(20.0)
-        .child(
-            Column::new()
-                .spacing(20.0)
-                .main_axis_alignment(MainAxisAlignment::Start)
-                .cross_axis_alignment(CrossAxisAlignment::Stretch)
-                .children(vec![
-                    // Header Section
-                    create_header(),
-                    
-                    // Content Section (Row with Sidebar and Main Content)
-                    Box::new(
-                        Row::new()
-                            .spacing(20.0)
-                            .children(vec![
-                                // Sidebar
-                                create_sidebar(),
-                                // Main Content Area
-                                create_main_content(),
-                            ])
-                    ) as Box<dyn Widget>,
-                ])
-        );
+    let main_container = InspectorOverlay::new(
+        Container::new()
+            .background(Color::rgba(0.95, 0.95, 0.97, 1.0)) // Light gray background
+            .padding(20.0)
+            .child(
+                Column::new()
+                    .spacing(20.0)
+                    .main_axis_alignment(MainAxisAlignment::Start)
+                    .cross_axis_alignment(CrossAxisAlignment::Stretch)
+                    .children(vec![
+                        // Header Section
+                        create_header(),
+                        // Content Section (Row with Sidebar and Main Content)
+                        Box::new(Row::new().spacing(20.0).children(vec![
+                            // Sidebar
+                            create_sidebar(),
+                            // Main Content Area
+                            create_main_content(),
+                        ])) as Box<dyn Widget>,
+                    ]),
+            ),
+    );
 
     app.set_root(Box::new(main_container));
 
@@ -58,55 +53,67 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn create_header() -> Box<dyn Widget> {
-    Box::new(Container::new()
-        .background(Color::rgba(1.0, 1.0, 1.0, 1.0))
-        .padding(15.0)
-        .border_radius(8.0)
-        .child(
-            Row::new()
-                .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                .cross_axis_alignment(CrossAxisAlignment::Center)
-                .children(vec![
-                    Box::new(
-                        Text::new("StratoUI Dashboard")
-                            .font_size(24.0)
-                            .font_weight(FontWeight::Bold)
-                            .color(Color::rgba(0.1, 0.1, 0.2, 1.0))
-                    ) as Box<dyn Widget>,
-                    Box::new(
-                        Row::new()
-                            .spacing(10.0)
-                            .children(vec![
-                                Box::new(Button::new("Settings").ghost()) as Box<dyn Widget>,
-                                Box::new(Button::new("Profile").primary()) as Box<dyn Widget>,
-                            ])
-                    ) as Box<dyn Widget>
-                ])
-        ))
+    Box::new(
+        Container::new()
+            .background(Color::rgba(1.0, 1.0, 1.0, 1.0))
+            .padding(15.0)
+            .border_radius(8.0)
+            .child(
+                Row::new()
+                    .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                    .cross_axis_alignment(CrossAxisAlignment::Center)
+                    .children(vec![
+                        Box::new(
+                            Text::new("StratoUI Dashboard")
+                                .font_size(24.0)
+                                .font_weight(FontWeight::Bold)
+                                .color(Color::rgba(0.1, 0.1, 0.2, 1.0)),
+                        ) as Box<dyn Widget>,
+                        Box::new(Row::new().spacing(10.0).children(vec![
+                            Box::new(Button::new("Settings").ghost()) as Box<dyn Widget>,
+                            Box::new(Button::new("Profile").primary()) as Box<dyn Widget>,
+                        ])) as Box<dyn Widget>,
+                    ]),
+            ),
+    )
 }
 
 fn create_sidebar() -> Box<dyn Widget> {
-    Box::new(Container::new()
-        .width(200.0)
-        .background(Color::rgba(1.0, 1.0, 1.0, 1.0))
-        .padding(10.0)
-        .border_radius(8.0)
-        .child(
-            Column::new()
-                .spacing(5.0)
-                .cross_axis_alignment(CrossAxisAlignment::Stretch)
-                .children(vec![
-                    Box::new(Text::new("MENU").font_size(12.0).color(Color::rgba(0.5, 0.5, 0.5, 1.0))) as Box<dyn Widget>,
-                    Box::new(Button::new("Dashboard").ghost().on_click(|| println!("Dashboard clicked"))) as Box<dyn Widget>,
-                    Box::new(Button::new("Analytics").ghost()) as Box<dyn Widget>,
-                    Box::new(Button::new("Reports").ghost()) as Box<dyn Widget>,
-                    Box::new(Button::new("Users").ghost()) as Box<dyn Widget>,
-                    Box::new(Container::new().height(20.0)) as Box<dyn Widget>, // Spacer
-                    Box::new(Text::new("SYSTEM").font_size(12.0).color(Color::rgba(0.5, 0.5, 0.5, 1.0))) as Box<dyn Widget>,
-                    Box::new(Button::new("Configuration").ghost()) as Box<dyn Widget>,
-                    Box::new(Button::new("Logs").ghost()) as Box<dyn Widget>,
-                ])
-        ))
+    Box::new(
+        Container::new()
+            .width(200.0)
+            .background(Color::rgba(1.0, 1.0, 1.0, 1.0))
+            .padding(10.0)
+            .border_radius(8.0)
+            .child(
+                Column::new()
+                    .spacing(5.0)
+                    .cross_axis_alignment(CrossAxisAlignment::Stretch)
+                    .children(vec![
+                        Box::new(
+                            Text::new("MENU")
+                                .font_size(12.0)
+                                .color(Color::rgba(0.5, 0.5, 0.5, 1.0)),
+                        ) as Box<dyn Widget>,
+                        Box::new(
+                            Button::new("Dashboard")
+                                .ghost()
+                                .on_click(|| println!("Dashboard clicked")),
+                        ) as Box<dyn Widget>,
+                        Box::new(Button::new("Analytics").ghost()) as Box<dyn Widget>,
+                        Box::new(Button::new("Reports").ghost()) as Box<dyn Widget>,
+                        Box::new(Button::new("Users").ghost()) as Box<dyn Widget>,
+                        Box::new(Container::new().height(20.0)) as Box<dyn Widget>, // Spacer
+                        Box::new(
+                            Text::new("SYSTEM")
+                                .font_size(12.0)
+                                .color(Color::rgba(0.5, 0.5, 0.5, 1.0)),
+                        ) as Box<dyn Widget>,
+                        Box::new(Button::new("Configuration").ghost()) as Box<dyn Widget>,
+                        Box::new(Button::new("Logs").ghost()) as Box<dyn Widget>,
+                    ]),
+            ),
+    )
 }
 
 fn create_main_content() -> Box<dyn Widget> {
@@ -133,7 +140,7 @@ fn create_main_content() -> Box<dyn Widget> {
                             })
                     ) as Box<dyn Widget>,
                     Box::new(Container::new().height(20.0)) as Box<dyn Widget>, // Spacer
-                    
+
                     // Cards Row
                     Box::new(
                         Row::new()
@@ -144,9 +151,9 @@ fn create_main_content() -> Box<dyn Widget> {
                                 create_card("Server Load", "42%", Color::rgba(1.0, 0.6, 0.2, 0.1)),
                             ])
                     ) as Box<dyn Widget>,
-                    
+
                     Box::new(Container::new().height(20.0)) as Box<dyn Widget>, // Spacer
-                    
+
                     // Typography Showcase
                     Box::new(Text::new("Typography & Spacing").font_size(18.0).font_weight(FontWeight::Medium)) as Box<dyn Widget>,
                     Box::new(
@@ -168,19 +175,29 @@ fn create_main_content() -> Box<dyn Widget> {
 }
 
 fn create_card(title: &str, value: &str, bg_color: Color) -> Box<dyn Widget> {
-    Box::new(Container::new()
-        .width(150.0)
-        .height(100.0)
-        .background(bg_color)
-        .border_radius(8.0)
-        .padding(15.0)
-        .child(
-            Column::new()
-                .main_axis_alignment(MainAxisAlignment::Center)
-                .cross_axis_alignment(CrossAxisAlignment::Start)
-                .children(vec![
-                    Box::new(Text::new(title).font_size(14.0).color(Color::rgba(0.4, 0.4, 0.4, 1.0))) as Box<dyn Widget>,
-                    Box::new(Text::new(value).font_size(24.0).font_weight(FontWeight::Bold)) as Box<dyn Widget>,
-                ])
-        ))
+    Box::new(
+        Container::new()
+            .width(150.0)
+            .height(100.0)
+            .background(bg_color)
+            .border_radius(8.0)
+            .padding(15.0)
+            .child(
+                Column::new()
+                    .main_axis_alignment(MainAxisAlignment::Center)
+                    .cross_axis_alignment(CrossAxisAlignment::Start)
+                    .children(vec![
+                        Box::new(
+                            Text::new(title)
+                                .font_size(14.0)
+                                .color(Color::rgba(0.4, 0.4, 0.4, 1.0)),
+                        ) as Box<dyn Widget>,
+                        Box::new(
+                            Text::new(value)
+                                .font_size(24.0)
+                                .font_weight(FontWeight::Bold),
+                        ) as Box<dyn Widget>,
+                    ]),
+            ),
+    )
 }

--- a/examples/comprehensive_test/src/main.rs
+++ b/examples/comprehensive_test/src/main.rs
@@ -1,88 +1,90 @@
-use strato_platform::{
-    application::Application,
-    window::WindowBuilder,
-};
-use strato_widgets::{
-    Button, ButtonStyle,
-    Column,
-    Container,
-    Row,
-    Flex,
-    Text,
-    text::FontWeight,
-    input::{TextInput, InputType},
-    Dropdown,
-    Widget,
-    layout::{MainAxisAlignment, CrossAxisAlignment},
-};
+use strato_core::inspector::{inspector, InspectorConfig};
 use strato_core::types::Color;
+use strato_platform::{application::Application, window::WindowBuilder};
+use strato_widgets::{
+    input::{InputType, TextInput},
+    layout::{CrossAxisAlignment, MainAxisAlignment},
+    text::FontWeight,
+    Button, ButtonStyle, Column, Container, Dropdown, Flex, InspectorOverlay, Row, Text, Widget,
+};
 use tracing::{info, warn};
 use tracing_subscriber::prelude::*;
 
 // Theme Colors
-fn theme_bg() -> Color { Color::rgba(0.09, 0.09, 0.11, 1.0) } // #17171C
-fn theme_surface() -> Color { Color::rgba(0.13, 0.13, 0.16, 1.0) } // #212129
-fn theme_surface_hover() -> Color { Color::rgba(0.16, 0.16, 0.20, 1.0) } // #292933
-fn theme_accent() -> Color { Color::rgba(0.39, 0.35, 0.88, 1.0) } // #6459E1
-fn theme_text_primary() -> Color { Color::rgba(0.95, 0.95, 0.97, 1.0) }
-fn theme_text_secondary() -> Color { Color::rgba(0.60, 0.60, 0.65, 1.0) }
+fn theme_bg() -> Color {
+    Color::rgba(0.09, 0.09, 0.11, 1.0)
+} // #17171C
+fn theme_surface() -> Color {
+    Color::rgba(0.13, 0.13, 0.16, 1.0)
+} // #212129
+fn theme_surface_hover() -> Color {
+    Color::rgba(0.16, 0.16, 0.20, 1.0)
+} // #292933
+fn theme_accent() -> Color {
+    Color::rgba(0.39, 0.35, 0.88, 1.0)
+} // #6459E1
+fn theme_text_primary() -> Color {
+    Color::rgba(0.95, 0.95, 0.97, 1.0)
+}
+fn theme_text_secondary() -> Color {
+    Color::rgba(0.60, 0.60, 0.65, 1.0)
+}
 const BORDER_RADIUS: f32 = 12.0;
 
 fn main() -> anyhow::Result<()> {
     // Setup logging to file
     let file_appender = tracing_appender::rolling::daily("logs", "comprehensive_test.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-    
+
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer()
-            .with_writer(non_blocking)
-            .with_ansi(false)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false),
         )
-        .with(tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stdout)
-        )
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stdout))
         .init();
 
     info!("Starting Comprehensive Test Example - Revolutionized UI");
+
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
 
     // Create application
     let window_builder = WindowBuilder::new()
         .with_title("StratoUI Dashboard")
         .with_size(1280.0, 900.0)
         .resizable(true);
-        
+
     let mut app = Application::new("StratoUI Dashboard", window_builder);
 
     // Create UI structure
-    let main_container = Container::new()
-        .background(theme_bg())
-        .padding(30.0)
-        .child(
+    let main_container = InspectorOverlay::new(
+        Container::new().background(theme_bg()).padding(30.0).child(
             Column::new()
                 .spacing(30.0)
                 .main_axis_alignment(MainAxisAlignment::Start)
                 .cross_axis_alignment(CrossAxisAlignment::Stretch)
                 .children(vec![
                     create_header(),
-                    
                     // Main Content Grid (simulated with Row/Column)
-                    Box::new(Row::new()
-                        .spacing(30.0)
-                        .cross_axis_alignment(CrossAxisAlignment::Start)
-                        .children(vec![
-                            // Left Column (Interactive)
-                            Box::new(Flex::new(
-                                create_interactive_section()
-                            )) as Box<dyn Widget>,
-                            
-                            // Right Column (Layouts/Cards)
-                            Box::new(Flex::new(
-                                create_layout_section()
-                            )) as Box<dyn Widget>,
-                        ])
+                    Box::new(
+                        Row::new()
+                            .spacing(30.0)
+                            .cross_axis_alignment(CrossAxisAlignment::Start)
+                            .children(vec![
+                                // Left Column (Interactive)
+                                Box::new(Flex::new(create_interactive_section()))
+                                    as Box<dyn Widget>,
+                                // Right Column (Layouts/Cards)
+                                Box::new(Flex::new(create_layout_section())) as Box<dyn Widget>,
+                            ]),
                     ) as Box<dyn Widget>,
-                ])
-        );
+                ]),
+        ),
+    );
 
     app.set_root(Box::new(main_container));
 
@@ -91,19 +93,17 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn create_header() -> Box<dyn Widget> {
-    Box::new(Container::new()
-        .background(theme_surface())
-        .padding(25.0)
-        .border_radius(BORDER_RADIUS)
-        .child(
-            Row::new()
-                .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                .cross_axis_alignment(CrossAxisAlignment::Center)
-                .children(vec![
-                    Box::new(
-                        Column::new()
-                            .spacing(5.0)
-                            .children(vec![
+    Box::new(
+        Container::new()
+            .background(theme_surface())
+            .padding(25.0)
+            .border_radius(BORDER_RADIUS)
+            .child(
+                Row::new()
+                    .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                    .cross_axis_alignment(CrossAxisAlignment::Center)
+                    .children(vec![
+                        Box::new(Column::new().spacing(5.0).children(vec![
                                 Box::new(
                                     Text::new("StratoUI Dashboard")
                                         .font_size(28.0)
@@ -115,13 +115,8 @@ fn create_header() -> Box<dyn Widget> {
                                         .font_size(14.0)
                                         .color(theme_text_secondary())
                                 ) as Box<dyn Widget>,
-                            ])
-                    ) as Box<dyn Widget>,
-                    
-                    Box::new(
-                        Row::new()
-                            .spacing(15.0)
-                            .children(vec![
+                            ])) as Box<dyn Widget>,
+                        Box::new(Row::new().spacing(15.0).children(vec![
                                 Box::new(
                                     Button::new("Documentation")
                                         .outline()
@@ -132,18 +127,15 @@ fn create_header() -> Box<dyn Widget> {
                                         .primary()
                                         .on_click(|| info!("New Project clicked"))
                                 ) as Box<dyn Widget>,
-                            ])
-                    ) as Box<dyn Widget>,
-                ])
-        ))
+                            ])) as Box<dyn Widget>,
+                    ]),
+            ),
+    )
 }
 
 fn create_interactive_section() -> Box<dyn Widget> {
-    Box::new(Column::new()
-        .spacing(20.0)
-        .children(vec![
+    Box::new(Column::new().spacing(20.0).children(vec![
             create_section_title("Controls & Inputs"),
-            
             Container::new()
                 .background(theme_surface())
                 .padding(20.0)
@@ -154,140 +146,168 @@ fn create_interactive_section() -> Box<dyn Widget> {
                         .cross_axis_alignment(CrossAxisAlignment::Stretch)
                         .children(vec![
                             // Buttons Group
-                            Box::new(Column::new()
-                                .spacing(10.0)
-                                .children(vec![
-                                    Box::new(Text::new("Buttons").font_size(14.0).color(theme_text_secondary())) as Box<dyn Widget>,
-                                    Box::new(Row::new()
-                                        .spacing(10.0)
-                                        .children(vec![
-                                            Box::new(Flex::new(Box::new(Button::new("Primary").primary())).flex(1.0)) as Box<dyn Widget>,
-                                            Box::new(Flex::new(Box::new(Button::new("Secondary").secondary())).flex(1.0)) as Box<dyn Widget>,
-                                            Box::new(Flex::new(Box::new(Button::new("Danger").danger())).flex(1.0)) as Box<dyn Widget>,
-                                        ])
+                            Box::new(
+                                Column::new().spacing(10.0).children(vec![
+                                    Box::new(
+                                        Text::new("Buttons")
+                                            .font_size(14.0)
+                                            .color(theme_text_secondary()),
                                     ) as Box<dyn Widget>,
-                                ])
+                                    Box::new(
+                                        Row::new().spacing(10.0).children(vec![
+                                            Box::new(
+                                                Flex::new(Box::new(
+                                                    Button::new("Primary").primary(),
+                                                ))
+                                                .flex(1.0),
+                                            )
+                                                as Box<dyn Widget>,
+                                            Box::new(
+                                                Flex::new(Box::new(
+                                                    Button::new("Secondary").secondary(),
+                                                ))
+                                                .flex(1.0),
+                                            )
+                                                as Box<dyn Widget>,
+                                            Box::new(
+                                                Flex::new(Box::new(Button::new("Danger").danger()))
+                                                    .flex(1.0),
+                                            )
+                                                as Box<dyn Widget>,
+                                        ]),
+                                    ) as Box<dyn Widget>,
+                                ]),
                             ) as Box<dyn Widget>,
-
                             // Dropdown Group
-                            Box::new(Column::new()
-                                .spacing(10.0)
-                                .children(vec![
-                                    Box::new(Text::new("Selection").font_size(14.0).color(theme_text_secondary())) as Box<dyn Widget>,
+                            Box::new(
+                                Column::new().spacing(10.0).children(vec![
+                                    Box::new(
+                                        Text::new("Selection")
+                                            .font_size(14.0)
+                                            .color(theme_text_secondary()),
+                                    ) as Box<dyn Widget>,
                                     Box::new(
                                         Dropdown::new()
                                             .add_value("Development".to_string())
                                             .add_value("Staging".to_string())
                                             .add_value("Production".to_string())
-                                            .placeholder("Select Environment".to_string())
+                                            .placeholder("Select Environment".to_string()),
                                     ) as Box<dyn Widget>,
-                                ])
+                                ]),
                             ) as Box<dyn Widget>,
-
                             // Inputs Group
-                            Box::new(Column::new()
-                                .spacing(15.0)
-                                .children(vec![
-                                    Box::new(Text::new("Authentication").font_size(14.0).color(theme_text_secondary())) as Box<dyn Widget>,
+                            Box::new(
+                                Column::new().spacing(15.0).children(vec![
                                     Box::new(
-                                        TextInput::new()
-                                            .placeholder("Username or Email")
+                                        Text::new("Authentication")
+                                            .font_size(14.0)
+                                            .color(theme_text_secondary()),
                                     ) as Box<dyn Widget>,
+                                    Box::new(TextInput::new().placeholder("Username or Email"))
+                                        as Box<dyn Widget>,
                                     Box::new(
                                         TextInput::new()
                                             .placeholder("Password")
-                                            .input_type(InputType::Password)
+                                            .input_type(InputType::Password),
                                     ) as Box<dyn Widget>,
-                                ])
+                                ]),
                             ) as Box<dyn Widget>,
-                        ])
+                        ]),
                 )
-                .into_boxed()
-        ])
-    )
+                .into_boxed(),
+        ]))
 }
 
 fn create_layout_section() -> Box<dyn Widget> {
-    Box::new(Column::new()
-        .spacing(20.0)
-        .children(vec![
+    Box::new(Column::new().spacing(20.0).children(vec![
             create_section_title("Project Status"),
-            
             // Stats Row
-            Box::new(Row::new()
-                .spacing(20.0)
-                .children(vec![
-                    create_stat_card("Active Users", "12.5k", "+15%", theme_accent()),
-                    create_stat_card("Server Load", "42%", "-5%", Color::rgba(0.2, 0.8, 0.4, 1.0)),
-                    create_stat_card("Errors", "0.01%", "-2%", Color::rgba(0.9, 0.3, 0.3, 1.0)),
-                ])
-            ) as Box<dyn Widget>,
-            
+            Box::new(Row::new().spacing(20.0).children(vec![
+                create_stat_card("Active Users", "12.5k", "+15%", theme_accent()),
+                create_stat_card("Server Load", "42%", "-5%", Color::rgba(0.2, 0.8, 0.4, 1.0)),
+                create_stat_card("Errors", "0.01%", "-2%", Color::rgba(0.9, 0.3, 0.3, 1.0)),
+            ])) as Box<dyn Widget>,
             // Detailed Cards
-            Box::new(Container::new()
-                .background(theme_surface())
-                .padding(20.0)
-                .border_radius(BORDER_RADIUS)
-                .child(
-                    Column::new()
-                        .spacing(15.0)
-                        .children(vec![
-                            Box::new(Text::new("Recent Activity").font_size(16.0).font_weight(FontWeight::SemiBold).color(theme_text_primary())) as Box<dyn Widget>,
+            Box::new(
+                Container::new()
+                    .background(theme_surface())
+                    .padding(20.0)
+                    .border_radius(BORDER_RADIUS)
+                    .child(
+                        Column::new().spacing(15.0).children(vec![
+                            Box::new(
+                                Text::new("Recent Activity")
+                                    .font_size(16.0)
+                                    .font_weight(FontWeight::SemiBold)
+                                    .color(theme_text_primary()),
+                            ) as Box<dyn Widget>,
                             create_activity_item("Deployment #1024", "Successful", "2 mins ago"),
                             create_activity_item("Database Backup", "Processing", "15 mins ago"),
                             create_activity_item("User Registration", "New User", "1 hour ago"),
-                        ])
-                )
+                        ]),
+                    ),
             ) as Box<dyn Widget>,
-        ])
-    )
+        ]))
 }
 
 fn create_section_title(title: &str) -> Box<dyn Widget> {
-    Box::new(Text::new(title)
-        .font_size(18.0)
-        .font_weight(FontWeight::SemiBold)
-        .color(theme_text_primary())
+    Box::new(
+        Text::new(title)
+            .font_size(18.0)
+            .font_weight(FontWeight::SemiBold)
+            .color(theme_text_primary()),
     )
 }
 
 fn create_stat_card(label: &str, value: &str, trend: &str, trend_color: Color) -> Box<dyn Widget> {
-    Box::new(Flex::new(Box::new(Container::new()
-        .background(theme_surface())
-        .padding(20.0)
-        .border_radius(BORDER_RADIUS)
-        .child(
-            Column::new()
-                .spacing(10.0)
-                .children(vec![
-                    Box::new(Text::new(label).font_size(14.0).color(theme_text_secondary())) as Box<dyn Widget>,
-                    Box::new(Text::new(value).font_size(24.0).font_weight(FontWeight::Bold).color(theme_text_primary())) as Box<dyn Widget>,
-                    Box::new(Text::new(trend).font_size(12.0).color(trend_color)) as Box<dyn Widget>,
-                ])
-        ))))
+    Box::new(Flex::new(Box::new(
+        Container::new()
+            .background(theme_surface())
+            .padding(20.0)
+            .border_radius(BORDER_RADIUS)
+            .child(Column::new().spacing(10.0).children(vec![
+                    Box::new(
+                        Text::new(label)
+                            .font_size(14.0)
+                            .color(theme_text_secondary()),
+                    ) as Box<dyn Widget>,
+                    Box::new(
+                        Text::new(value)
+                            .font_size(24.0)
+                            .font_weight(FontWeight::Bold)
+                            .color(theme_text_primary()),
+                    ) as Box<dyn Widget>,
+                    Box::new(Text::new(trend).font_size(12.0).color(trend_color))
+                        as Box<dyn Widget>,
+                ])),
+    )))
 }
 
 fn create_activity_item(title: &str, status: &str, time: &str) -> Box<dyn Widget> {
-    Box::new(Container::new()
-        .background(theme_surface_hover())
-        .padding(12.0)
-        .border_radius(8.0)
-        .child(
-            Row::new()
-                .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                .cross_axis_alignment(CrossAxisAlignment::Center)
-                .children(vec![
-                    Box::new(
-                        Column::new()
-                            .spacing(4.0)
-                            .children(vec![
-                                Box::new(Text::new(title).font_size(14.0).color(theme_text_primary())) as Box<dyn Widget>,
-                                Box::new(Text::new(status).font_size(12.0).color(theme_accent())) as Box<dyn Widget>,
-                            ])
-                    ) as Box<dyn Widget>,
-                    Box::new(Text::new(time).font_size(12.0).color(theme_text_secondary())) as Box<dyn Widget>,
-                ])
-        ))
+    Box::new(
+        Container::new()
+            .background(theme_surface_hover())
+            .padding(12.0)
+            .border_radius(8.0)
+            .child(
+                Row::new()
+                    .main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                    .cross_axis_alignment(CrossAxisAlignment::Center)
+                    .children(vec![
+                        Box::new(Column::new().spacing(4.0).children(vec![
+                            Box::new(Text::new(title).font_size(14.0).color(theme_text_primary()))
+                                as Box<dyn Widget>,
+                            Box::new(Text::new(status).font_size(12.0).color(theme_accent()))
+                                as Box<dyn Widget>,
+                        ])) as Box<dyn Widget>,
+                        Box::new(
+                            Text::new(time)
+                                .font_size(12.0)
+                                .color(theme_text_secondary()),
+                        ) as Box<dyn Widget>,
+                    ]),
+            ),
+    )
 }
 
 // Extension trait helper to box widgets easily

--- a/examples/custom_init/src/main.rs
+++ b/examples/custom_init/src/main.rs
@@ -1,5 +1,6 @@
-use strato_ui::{InitBuilder, InitConfig};
+use strato_core::inspector::{inspector, InspectorConfig};
 use strato_core::Result;
+use strato_ui::{InitBuilder, InitConfig};
 
 fn main() -> Result<()> {
     println!("StratoUI Custom Initialization Example");
@@ -9,10 +10,16 @@ fn main() -> Result<()> {
     println!("\n1. Basic initialization with default config:");
     let mut builder = InitBuilder::new();
     builder.init_all()?;
-    
+
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
     println!("   Core: ✓");
     println!("   Widgets: ✓");
     println!("   Platform: ✓");
+    println!("   Inspector: ✓ Enabled for runtime overlays");
     println!("   Complete: ✓");
 
     // Example 2: Check global text renderer

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,17 +1,18 @@
 //! Hello World example for StratoSDK showing state management and modern UI
-use strato_sdk::prelude::*;
-use strato_sdk::strato_widgets::{
-    Button, Column, Container, Text,
-    text::TextAlign,
-    layout::{MainAxisAlignment, CrossAxisAlignment},
-};
-use strato_sdk::strato_platform::{
-    ApplicationBuilder, WindowBuilder,
-    init::{InitBuilder, InitConfig},
-};
-use strato_sdk::strato_core::types::Color;
-use strato_sdk::strato_core::state::Signal;
 use std::sync::{Arc, Mutex};
+use strato_sdk::prelude::*;
+use strato_sdk::strato_core::inspector::{inspector, InspectorConfig};
+use strato_sdk::strato_core::state::Signal;
+use strato_sdk::strato_core::types::Color;
+use strato_sdk::strato_platform::{
+    init::{InitBuilder, InitConfig},
+    ApplicationBuilder, WindowBuilder,
+};
+use strato_sdk::strato_widgets::{
+    layout::{CrossAxisAlignment, MainAxisAlignment},
+    text::TextAlign,
+    Button, Column, Container, InspectorOverlay, Text,
+};
 
 #[derive(Clone, Debug)]
 struct HelloWorldState {
@@ -35,9 +36,10 @@ impl HelloWorldState {
         if count == 1 {
             self.message.set("First click! Keep going!".to_string());
         } else if count == 5 {
-             self.message.set("You're getting the hang of it!".to_string());
+            self.message
+                .set("You're getting the hang of it!".to_string());
         } else if count == 10 {
-             self.message.set("Double digits! 🚀".to_string());
+            self.message.set("Double digits! 🚀".to_string());
         }
     }
 }
@@ -51,17 +53,23 @@ fn main() -> anyhow::Result<()> {
         })
         .init_all()?;
 
+    // Keep the inspector available in all builds so the example showcases live debugging tools.
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
     println!("Hello World - StratoSDK initialized!");
 
     ApplicationBuilder::new()
         .title("Hello StratoSDK")
         .window(WindowBuilder::new().with_size(500.0, 400.0).resizable(true))
-        .run(build_ui())
+        .run(InspectorOverlay::new(build_ui()))
 }
 
 fn build_ui() -> impl Widget {
     let state = Arc::new(Mutex::new(HelloWorldState::default()));
-    
+
     // Main Window Background
     Container::new()
         .background(Color::rgb(0.05, 0.05, 0.05)) // Deep dark background
@@ -70,9 +78,7 @@ fn build_ui() -> impl Widget {
             Column::new()
                 .main_axis_alignment(MainAxisAlignment::Center)
                 .cross_axis_alignment(CrossAxisAlignment::Center)
-                .children(vec![
-                    Box::new(create_interaction_card(state))
-                ])
+                .children(vec![Box::new(create_interaction_card(state))]),
         )
 }
 
@@ -81,7 +87,7 @@ fn create_interaction_card(state: Arc<Mutex<HelloWorldState>>) -> impl Widget {
         let state = state.lock().unwrap();
         (state.counter.clone(), state.message.clone())
     };
-    
+
     // Card Container
     Container::new()
         .background(Color::rgb(0.12, 0.12, 0.12)) // Slightly lighter card
@@ -99,48 +105,41 @@ fn create_interaction_card(state: Arc<Mutex<HelloWorldState>>) -> impl Widget {
                         Container::new()
                             .width(60.0)
                             .height(60.0)
-                            .background(Color::rgb(0.25, 0.4, 0.9)) // Accent Blue
-                            // .corner_radius(30.0) // Circle
+                            .background(Color::rgb(0.25, 0.4, 0.9)), // Accent Blue
+                                                                     // .corner_radius(30.0) // Circle
                     ),
-                    
                     // Title
                     Box::new(
                         Text::new("Hello, StratoSDK")
                             .size(32.0)
                             .color(Color::WHITE)
-                            .align(TextAlign::Center)
+                            .align(TextAlign::Center),
                     ),
-                    
                     // Dynamic Message
                     Box::new(
                         Text::new("")
                             .bind(message_signal)
                             .size(16.0)
                             .color(Color::rgb(0.7, 0.7, 0.7))
-                            .align(TextAlign::Center)
+                            .align(TextAlign::Center),
                     ),
-                    
                     // Spacer
                     Box::new(Container::new().height(10.0)),
-                    
                     // Counter Display
                     Box::new(
                         Text::new("")
                             .bind(counter_signal.map(|c| format!("Clicks: {}", c)))
                             .size(48.0)
                             .color(Color::rgb(0.25, 0.8, 0.4)) // Green accent
-                            .align(TextAlign::Center)
+                            .align(TextAlign::Center),
                     ),
-                    
                     // Interactive Button
                     Box::new(
-                         Button::new("Increment Counter")
-                            .on_click(move || {
-                                let mut state = state.lock().unwrap();
-                                state.increment();
-                            })
-                            // .style(...) // if we had style API on button directly
+                        Button::new("Increment Counter").on_click(move || {
+                            let mut state = state.lock().unwrap();
+                            state.increment();
+                        }), // .style(...) // if we had style API on button directly
                     ),
-                ])
+                ]),
         )
 }

--- a/examples/macro_showcase/src/main.rs
+++ b/examples/macro_showcase/src/main.rs
@@ -1,16 +1,23 @@
-use strato_platform::{ApplicationBuilder, WindowBuilder};
-use strato_widgets::prelude::*;
+use strato_core::inspector::{inspector, InspectorConfig};
 use strato_core::types::Color;
 use strato_macros::view;
+use strato_platform::{ApplicationBuilder, WindowBuilder};
+use strato_widgets::prelude::*;
+use strato_widgets::InspectorOverlay;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
     let builder = ApplicationBuilder::new()
         .title("Macro DSL Showcase")
         .window(WindowBuilder::new().with_size(800.0, 600.0));
-    
+
     // Using the view! macro to declaratively build the UI
     let root = view! {
         Container {
@@ -43,5 +50,5 @@ async fn main() -> anyhow::Result<()> {
     // Build the widget tree using the registry
     let root_widget = registry.build(root);
 
-    builder.run(root_widget);
+    builder.run(InspectorOverlay::new(root_widget));
 }

--- a/examples/modern_dashboard/src/app.rs
+++ b/examples/modern_dashboard/src/app.rs
@@ -25,7 +25,7 @@ impl ModernDashboardApp {
 
         let sidebar = Sidebar::new(active_tab.clone()).build();
         let header = Header::new().build();
-        
+
         let view_switcher = ViewSwitcher::new(active_tab);
 
         let root = Container::new()
@@ -35,7 +35,7 @@ impl ModernDashboardApp {
                     .children(vec![
                         // Sidebar
                         sidebar,
-                        
+
                         // Main Content Area
                         Box::new(Flex::new(
                             Box::new(Column::new()
@@ -142,7 +142,7 @@ impl Widget for ViewSwitcher {
             last_tab: self.last_tab.clone(),
         })
     }
-    
+
     fn children(&self) -> Vec<&(dyn Widget + '_)> {
         let current_tab = self.active_tab.get();
         if let Some(view) = self.views.get(&current_tab) {

--- a/examples/modern_dashboard/src/components/activity_list.rs
+++ b/examples/modern_dashboard/src/components/activity_list.rs
@@ -32,7 +32,7 @@ impl ActivityList {
                             .font_size(18.0)
                             .font_weight(FontWeight::Bold)
                             .color(theme.text_primary)) as Box<dyn Widget>,
-                        
+
                         self.activity_item("New user registered", "2 min ago", theme.success),
                         self.activity_item("Server rebooted", "15 min ago", theme.warning),
                         self.activity_item("Database backup completed", "1 hour ago", theme.accent),
@@ -43,7 +43,7 @@ impl ActivityList {
 
     fn activity_item(&self, title: &str, time: &str, dot_color: strato_core::types::Color) -> Box<dyn Widget> {
         let theme = &self.theme;
-        
+
         Box::new(Container::new()
             .padding(SPACING_SM)
             .child(
@@ -57,7 +57,7 @@ impl ActivityList {
                             .height(10.0)
                             .border_radius(5.0)
                             .background(dot_color)) as Box<dyn Widget>,
-                            
+
                         // Content
                         Box::new(Flex::new(
                             Box::new(Column::new()

--- a/examples/modern_dashboard/src/components/animated_chart.rs
+++ b/examples/modern_dashboard/src/components/animated_chart.rs
@@ -1,5 +1,5 @@
 use strato_widgets::{
-    Widget, WidgetId, 
+    Widget, WidgetId,
     animation::{AnimationController, Curve},
 };
 // Clean imports:
@@ -48,7 +48,7 @@ impl Widget for AnimatedChart {
     fn layout(&mut self, constraints: strato_core::layout::Constraints) -> Size {
         // Take all available space, or default specific size if unbounded
         Size::new(
-            constraints.max_width.min(800.0).max(300.0), 
+            constraints.max_width.min(800.0).max(300.0),
             constraints.max_height.min(400.0).max(200.0)
         )
     }
@@ -65,15 +65,15 @@ impl Widget for AnimatedChart {
 
         for (i, &value) in self.data.iter().enumerate() {
             let x = layout.position.x + i as f32 * (bar_width + gap);
-            
+
             // Animate height
             let target_h = (value / max_val) * layout.size.height;
             let current_h = target_h * progress;
-            
+
             let y = layout.position.y + layout.size.height - current_h;
 
             let rect = Rect::new(x, y, bar_width, current_h);
-            
+
             // Use different opacity based on index to show it's dynamic
             let alpha = 0.5 + 0.5 * (i as f32 / bar_count as f32);
             let color = Color {

--- a/examples/modern_dashboard/src/components/sidebar.rs
+++ b/examples/modern_dashboard/src/components/sidebar.rs
@@ -51,10 +51,10 @@ impl Sidebar {
                         self.nav_item("Analytics", "analytics", active_tab.clone(), theme.clone()),
                         self.nav_item("Users", "users", active_tab.clone(), theme.clone()),
                         self.nav_item("Settings", "settings", active_tab.clone(), theme.clone()),
-                        
+
                         // Spacer
                         Box::new(Flex::new(Box::new(Container::new())).flex(1.0)) as Box<dyn Widget>,
-                        
+
                         // Bottom Area
                         Box::new(Container::new()
                             .background(theme.bg_tertiary)
@@ -79,7 +79,7 @@ impl Sidebar {
         // Note: Real interactivity would check active_signal value to change style
         // For now, we simulate basic structure
         let id_owned = id.to_string();
-        
+
         Box::new(Button::new(label)
             .secondary() // Use secondary style by default
             .on_click(move || {

--- a/examples/modern_dashboard/src/components/stats_card.rs
+++ b/examples/modern_dashboard/src/components/stats_card.rs
@@ -41,12 +41,12 @@ impl StatsCard {
                             Box::new(Text::new(&self.title)
                                 .color(theme.text_secondary)
                                 .font_size(14.0)) as Box<dyn Widget>,
-                            
+
                             Box::new(Text::new(&self.value)
                                 .color(theme.text_primary)
                                 .font_size(28.0)
                                 .font_weight(FontWeight::Bold)) as Box<dyn Widget>,
-                            
+
                             Box::new(Text::new(&self.trend)
                                 .color(trend_color)
                                 .font_size(12.0)) as Box<dyn Widget>,

--- a/examples/modern_dashboard/src/main.rs
+++ b/examples/modern_dashboard/src/main.rs
@@ -1,19 +1,24 @@
-use strato_core::{
-    types::Color,
-};
+use strato_core::inspector::{inspector, InspectorConfig};
+use strato_core::types::Color;
 use strato_platform::{application::ApplicationBuilder, window::WindowBuilder};
 use strato_widgets::{
-    prelude::*,
     container::Container,
-    text::Text,
     image::Image,
+    layout::{Column, Flex, Row},
+    prelude::*,
+    text::Text,
     top_bar::TopBar,
-    layout::{Column, Row, Flex}, 
+    InspectorOverlay,
 };
 
 fn main() {
     // We don't need registry for direct widget construction
-    let root_widget = build_ui();
+    inspector().configure(InspectorConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
+    let root_widget = InspectorOverlay::new(build_ui());
 
     ApplicationBuilder::new()
         .window(
@@ -22,23 +27,38 @@ fn main() {
                 .with_size(1200.0, 800.0)
                 .resizable(true)
                 .transparent(true) // Enable glassmorphism support
-                .decorations(true) // Restore native window controls
+                .decorations(true), // Restore native window controls
         )
         .run(root_widget);
 }
 
-
 // --- Theme Colors ---
 // Catppuccin-inspired Logic format (0.0-1.0)
 // --- Theme Colors (Refined) ---
-fn col_bg() -> Color { Color::rgba(0.13, 0.13, 0.18, 0.90) } // Semi-transparent background
-fn col_sidebar() -> Color { Color::rgba(0.18, 0.18, 0.25, 0.95) } 
-fn col_card_bg() -> Color { Color::rgba(0.20, 0.20, 0.28, 0.8) } // Glassy cards
-fn col_text() -> Color { Color::rgba(0.95, 0.95, 0.95, 1.0) }
-fn col_text_dim() -> Color { Color::rgba(0.70, 0.70, 0.80, 1.0) }
-fn col_subtext() -> Color { Color::rgba(0.60, 0.60, 0.70, 1.0) } 
-fn col_accent() -> Color { Color::rgba(0.12, 0.45, 0.98, 1.0) } 
-fn col_header() -> Color { Color::rgba(0.50, 0.50, 0.60, 1.0) }
+fn col_bg() -> Color {
+    Color::rgba(0.13, 0.13, 0.18, 0.90)
+} // Semi-transparent background
+fn col_sidebar() -> Color {
+    Color::rgba(0.18, 0.18, 0.25, 0.95)
+}
+fn col_card_bg() -> Color {
+    Color::rgba(0.20, 0.20, 0.28, 0.8)
+} // Glassy cards
+fn col_text() -> Color {
+    Color::rgba(0.95, 0.95, 0.95, 1.0)
+}
+fn col_text_dim() -> Color {
+    Color::rgba(0.70, 0.70, 0.80, 1.0)
+}
+fn col_subtext() -> Color {
+    Color::rgba(0.60, 0.60, 0.70, 1.0)
+}
+fn col_accent() -> Color {
+    Color::rgba(0.12, 0.45, 0.98, 1.0)
+}
+fn col_header() -> Color {
+    Color::rgba(0.50, 0.50, 0.60, 1.0)
+}
 
 fn build_ui() -> Container {
     Container::new()
@@ -58,7 +78,7 @@ fn build_ui() -> Container {
                         .children(vec![
                             // Window Controls Spacer
                             Box::new(Container::new().height(20.0).child(Text::new(""))),
-                            
+
                             // User Profile
                             Box::new(Container::new()
                                 .padding(16.0)
@@ -76,7 +96,7 @@ fn build_ui() -> Container {
                                     ])
                                 )
                             ),
-                            
+
                             // TIMELINES
                             section_header("TIMELINES"),
                             sidebar_item("Classic Timeline", "📅", false),
@@ -84,14 +104,14 @@ fn build_ui() -> Container {
                             sidebar_item("Federated", "🌐", false),
 
                             // ACCOUNT
-                            Box::new(Container::new().height(20.0).child(Text::new(""))), 
+                            Box::new(Container::new().height(20.0).child(Text::new(""))),
                             section_header("ACCOUNT"),
                             sidebar_item("Your Posts", "📝", false),
                             sidebar_item("Followers", "👥", false),
-                            sidebar_item("Following", "👤", true), 
+                            sidebar_item("Following", "👤", true),
                             sidebar_item("Bookmarks", "🔖", false),
                             sidebar_item("Favorites", "⭐️", false),
-                        
+
                             // Spacer (Pushes content down)
                             Box::new(Flex::new(
                                 Box::new(Container::new().height(1.0).child(Text::new("")))
@@ -106,7 +126,7 @@ fn build_ui() -> Container {
                                 .child(Row::new()
                                     .spacing(12.0)
                                     .children(vec![
-                                        Box::new(Text::new("sun").size(14.0)), 
+                                        Box::new(Text::new("sun").size(14.0)),
                                         Box::new(Text::new("Toggle Theme").color(col_text_dim()).size(14.0))
                                     ])
                                 )
@@ -117,7 +137,7 @@ fn build_ui() -> Container {
                         ])
                     )
                 ),
-                
+
                 // Main Content Area
                 Box::new(Container::new()
                     .padding(0.0)
@@ -140,23 +160,23 @@ fn build_ui() -> Container {
                                     .spacing(16.0)
                                     .children(vec![
                                         card_item(
-                                            "NDR", 
-                                            "@NDR", 
-                                            "Moin! Hier gibt's pro Tag 3-5 Nachrichten aus Hamburg...", 
+                                            "NDR",
+                                            "@NDR",
+                                            "Moin! Hier gibt's pro Tag 3-5 Nachrichten aus Hamburg...",
                                             "146 Posts  7 Following  5k Followers",
                                             "https://avatars.githubusercontent.com/u/1?v=4"
                                         ),
                                         card_item(
-                                            "tagesschau", 
-                                            "@tagesschau", 
-                                            "Hier trötet die tagesschau Nachrichten von https://www.tagesschau.de/", 
+                                            "tagesschau",
+                                            "@tagesschau",
+                                            "Hier trötet die tagesschau Nachrichten von https://www.tagesschau.de/",
                                             "683 Posts  4 Following  20k Followers",
                                             "https://avatars.githubusercontent.com/u/2?v=4"
                                         ),
                                         card_item(
-                                            "Simon Willison", 
-                                            "@simon", 
-                                            "Open source developer building tools to help journalists...", 
+                                            "Simon Willison",
+                                            "@simon",
+                                            "Open source developer building tools to help journalists...",
                                             "3k Posts  1k Following  17k Followers",
                                             "https://avatars.githubusercontent.com/u/3?v=4"
                                         ),
@@ -173,46 +193,54 @@ fn build_ui() -> Container {
 // --- Components ---
 
 fn section_header(title: &str) -> Box<dyn Widget> {
-    Box::new(Container::new()
-        .padding(16.0) // Left padding alignment
-        .margin(0.0)
-        .child(Text::new(title).color(col_header()).size(11.0))
+    Box::new(
+        Container::new()
+            .padding(16.0) // Left padding alignment
+            .margin(0.0)
+            .child(Text::new(title).color(col_header()).size(11.0)),
     )
 }
 
 fn sidebar_item(label: &str, icon: &str, active: bool) -> Box<dyn Widget> {
-    let bg_color = if active { col_accent() } else { Color::TRANSPARENT };
+    let bg_color = if active {
+        col_accent()
+    } else {
+        Color::TRANSPARENT
+    };
     let text_color = if active { Color::WHITE } else { col_subtext() };
     let label_clone = label.to_string();
-    
-    Box::new(Container::new()
-        .background(bg_color)
-        .margin(0.0)
-        .padding(10.0)
-        .border_radius(6.0) // Rounded active item
-        .width(240.0) // Slight inset from full width
-        .child(Row::new()
-            .spacing(12.0)
-            .children(vec![
+
+    Box::new(
+        Container::new()
+            .background(bg_color)
+            .margin(0.0)
+            .padding(10.0)
+            .border_radius(6.0) // Rounded active item
+            .width(240.0) // Slight inset from full width
+            .child(Row::new().spacing(12.0).children(vec![
                 Box::new(Text::new(icon).size(14.0)), // Smaller icons
-                Box::new(Text::new(label).color(text_color).size(14.0))
-            ])
-        )
-        .on_click(move || {
-            println!("Clicked sidebar item: {}", label_clone);
-        })
+                Box::new(Text::new(label).color(text_color).size(14.0)),
+            ]))
+            .on_click(move || {
+                println!("Clicked sidebar item: {}", label_clone);
+            }),
     )
 }
 
-fn card_item(name: &str, handle: &str, content: &str, stats: &str, avatar_url: &str) -> Box<dyn Widget> {
-    Box::new(Container::new()
-        .background(col_card_bg())
-        .padding(16.0)
-        .border_radius(10.0) // Smooth card rounding
-        .width(600.0) // Fixed card width for specific look
-        .child(Column::new()
-            .spacing(12.0)
-            .children(vec![
+fn card_item(
+    name: &str,
+    handle: &str,
+    content: &str,
+    stats: &str,
+    avatar_url: &str,
+) -> Box<dyn Widget> {
+    Box::new(
+        Container::new()
+            .background(col_card_bg())
+            .padding(16.0)
+            .border_radius(10.0) // Smooth card rounding
+            .width(600.0) // Fixed card width for specific look
+            .child(Column::new().spacing(12.0).children(vec![
                 // Header Row
                 Box::new(Row::new()
                     .spacing(12.0)
@@ -258,7 +286,6 @@ fn card_item(name: &str, handle: &str, content: &str, stats: &str, avatar_url: &
                     .padding(0.0)
                     .child(Text::new(stats).color(col_header()).size(12.0))
                 )
-            ])
-        )
+            ])),
     )
 }

--- a/examples/modern_dashboard/src/views/dashboard.rs
+++ b/examples/modern_dashboard/src/views/dashboard.rs
@@ -69,9 +69,9 @@ impl DashboardView {
                                                 Box::new(Text::new("Growth Analytics")
                                                     .font_size(20.0)
                                                     .color(theme.text_primary)) as Box<dyn Widget>,
-                                                
+
                                                 Box::new(AnimatedChart::new(vec![
-                                                    65.0, 40.0, 100.0, 85.0, 45.0, 92.0, 
+                                                    65.0, 40.0, 100.0, 85.0, 45.0, 92.0,
                                                     55.0, 70.0, 30.0, 60.0, 95.0, 80.0
                                                 ]).color(Color::rgb(0.4, 0.7, 1.0))) as Box<dyn Widget>
                                             ])


### PR DESCRIPTION
## Summary
- enable the inspector overlay across the example applications to showcase runtime debugging
- configure inspector defaults so examples keep instrumentation active in all build profiles
- wrap example roots with the overlay to highlight UI hierarchy, state snapshots, and layout data

## Testing
- cargo fmt
